### PR TITLE
Fix CZERTAINLY Keycloak theme for version Keycloak 24

### DIFF
--- a/custom_themes/themes/czertainly/login/template.ftl
+++ b/custom_themes/themes/czertainly/login/template.ftl
@@ -1,4 +1,4 @@
-<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true>
+<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 
@@ -29,7 +29,7 @@
         </div>
         </#if>
         <#nested "form">
-            </div> 
+            </div>
         </div>
 	</body>
 </html>


### PR DESCRIPTION
It turns that fix is pretty easy.  Error 
```
2024-06-04 10:03:42,305 SEVERE [freemarker.runtime] (executor-thread-1) Error executing FreeMarker template: freemarker.core._MiscTemplateException: Macro "registrationLayout" has no parameter with name "displayRequiredFields". Valid parameter names are: bodyClass, displayInfo, displayMessage
```
insists on adding displayRequiredFields to supported arguments for macro.

closes #1 